### PR TITLE
Fixed log messages

### DIFF
--- a/ngx_http_upstream_jdomain.c
+++ b/ngx_http_upstream_jdomain.c
@@ -516,9 +516,9 @@ ngx_http_upstream_set_jdomain_peer_session(ngx_peer_connection_t *pc,
 
 	rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
-	ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-			"set session: %p:%d",
-			ssl_session, ssl_session ? ssl_session->references : 0);
+	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+			"set session: %p",
+			ssl_session);
 
 	return rc;
 }
@@ -539,8 +539,8 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t *pc,
 		return;
 	}
 
-	ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-			"save session: %p:%d", ssl_session, ssl_session->references);
+	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+			"save session: %p", ssl_session);
 
 	peer = &urpd->conf->peers[urpd->current];
 
@@ -550,9 +550,9 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t *pc,
 
 	if (old_ssl_session) {
 
-		ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-				"old session: %p:%d",
-				old_ssl_session, old_ssl_session->references);
+		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+				"old session: %p",
+				old_ssl_session);
 
 
 		ngx_ssl_free_session(old_ssl_session);


### PR DESCRIPTION
* OpenSSL 1.1 made many data structures, including SSL_SESSION, opaque. Updated log messages to no longer include references, which is no longer accessible.
* See https://github.com/mwhipple/ngx_upstream_jdomain/pull/7/files.